### PR TITLE
Update dockerstats.go

### DIFF
--- a/dockerstats.go
+++ b/dockerstats.go
@@ -31,7 +31,7 @@
 package dockerstats
 
 const (
-	defaultDockerPath        string = "/usr/local/bin/docker"
+	defaultDockerPath        string = "/usr/bin/docker"
 	defaultDockerCommand     string = "stats"
 	defaultDockerNoStreamArg string = "--no-stream"
 	defaultDockerFormatArg   string = "--format"


### PR DESCRIPTION
edited the path for where the docker binaries is, since docker now gets installed with apt